### PR TITLE
fixed AppVeyor issue with task npmInstall (Java8 commented). fix #29

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: groovy 
 jdk:
-  - oraclejdk8
+# commented Java8 untill compatibility is fixed
+#  - oraclejdk8
   - oraclejdk7
   - openjdk7
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,11 +7,14 @@ environment:
   TERM: dumb
   matrix:
     - JAVA_HOME: C:\Program Files\Java\jdk1.7.0
-    - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+    # Currently Java8 is disabled due to a bug
+    # - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
 install:
-  - SET PATH=%JAVA_HOME%\bin;
+  - npm -g install npm@2
+  - set PATH=%APPDATA%\npm;%JAVA_HOME%\bin;%PATH%
   - echo %PATH%
-  - gradlew.bat clean npmInstall
+  - gradlew.bat clean npmInstall --stacktrace
+  - set JAVA_OPTS=-XX:MaxPermSize=1024m -Xmx1512m
 build_script:
   - gradlew.bat -u -i build
 test_script:


### PR DESCRIPTION
Fixed the issue that caused task npmInstall fail in AppVeyour. Just repacing the default version of npm during the install step makes it work:
```
npm -g install npm@2
```
Details here: https://github.com/appveyor/ci/issues/102#issuecomment-69798303

However this does not make the build work, because other errors occur due to issues on windows, but tests can be executed now at least :smiley: I'll just open another issue about this.

Also Java 8 has been commented until it compatibility is fixed.