### PR TITLE
Cater for 'negative' obj values of 0, false etc.

### DIFF
--- a/src/main/resources/META-INF/resources/grooscript.js
+++ b/src/main/resources/META-INF/resources/grooscript.js
@@ -2889,7 +2889,7 @@
 
     //Convert a javascript object to 'groovy', if you define groovy type, will use it, and not a map
     gs.toGroovy = function(obj, objClass) {
-        var result;
+        var result = obj;
         if (obj !== undefined && !isFunction(obj)) {
             if (obj instanceof Array) {
                 result = gs.list([]);

--- a/src/test/groovy/org/grooscript/GrooScriptSpec.groovy
+++ b/src/test/groovy/org/grooscript/GrooScriptSpec.groovy
@@ -149,7 +149,7 @@ class GrooScriptSpec extends Specification {
         GrooScript.toJsObj(data) == data
 
         where:
-        testData << [null, '', 'hello', 55, [1, 2, 3], [one: 1, two: 2]]
+        testData << [null, '', 'hello', 55, [1, 2, 3], [one: 1, two: 2], 0, false]
     }
 
     @Unroll


### PR DESCRIPTION
Simple fix to handle primitive 'negative' types correctly e.g. 0 and false