### PR TITLE
Speed of conversion optimization

### DIFF
--- a/src/main/groovy/org/grooscript/builder/HtmlBuilder.groovy
+++ b/src/main/groovy/org/grooscript/builder/HtmlBuilder.groovy
@@ -15,58 +15,60 @@ package org.grooscript.builder
 
 class HtmlBuilder {
 
-    private String htmCd
+    private StringBuffer htmCd = new StringBuffer()
 
     HtmlBuilder() {
-        htmCd = ''
     }
 
     static String build(@DelegatesTo(HtmlBuilder) Closure closure) {
         def mc = new ExpandoMetaClass(HtmlBuilder, false, true)
         mc.initialize()
         def builder = new HtmlBuilder()
+
         builder.metaClass = mc
         closure.delegate = builder
         closure()
 
-        builder.htmCd
+        builder.htmCd.toString()
     }
 
     def yield(String text) {
         text.each { ch ->
             switch (ch) {
                 case '&':
-                    htmCd += "&amp;"
+                    htmCd << "&amp;"
                     break
                 case '<':
-                    htmCd += "&lt;"
+                    htmCd << "&lt;"
                     break
                 case '>':
-                    htmCd += "&gt;"
+                    htmCd << "&gt;"
                     break
                 case '"':
-                    htmCd += "&quot;"
+                    htmCd << "&quot;"
                     break
                 case '\'':
-                    htmCd +=  "&apos;"
+                    htmCd <<  "&apos;"
                     break
                 default:
-                    htmCd += ch
+                    htmCd << ch
                     break
             }
         }
     }
 
     def yieldUnescaped(String text) {
-        htmCd += text
+        htmCd << text
     }
 
     def comment(String text) {
-        htmCd += '<!--' + text + '-->'
+        htmCd << '<!--'
+        htmCd << text
+        htmCd << '-->'
     }
 
     def newLine() {
-        htmCd += '\n'
+        htmCd << '\n'
     }
 
     def methodMissing(String name, args) {
@@ -75,13 +77,13 @@ class HtmlBuilder {
     }
 
     def tagSolver = { String name, args ->
-        htmCd += "<${name}"
+        htmCd << "<${name}"
         if (args && args.size() > 0 && !(args[0] instanceof String) && !(args[0] instanceof Closure)) {
             args[0].each { key, value ->
-                htmCd += " ${key}='${value}'"
+                htmCd << " ${key}='${value}'"
             }
         }
-        htmCd += !args ? '/>' : '>'
+        htmCd << (!args ? '/>' : '>')
         if (args) {
             if (args.size() == 1 && args[0] instanceof String) {
                 yield args[0]
@@ -95,7 +97,7 @@ class HtmlBuilder {
                     yield lastArg
                 }
             }
-            htmCd += "</${name}>"
+            htmCd << "</${name}>"
         }
     }
 }

--- a/src/main/groovy/org/grooscript/convert/GsConverter.groovy
+++ b/src/main/groovy/org/grooscript/convert/GsConverter.groovy
@@ -167,7 +167,7 @@ class GsConverter {
                 }
             }
 
-            result = out.resultScript
+            result = out.finalScript
         }
         result
     }

--- a/src/main/groovy/org/grooscript/convert/Out.groovy
+++ b/src/main/groovy/org/grooscript/convert/Out.groovy
@@ -17,40 +17,53 @@ import static org.grooscript.util.Util.LINE_SEPARATOR as LS
 
 class Out {
 
-    private static final TAB = '  '
+    private static final String TAB = '  '
 
     int indent = 0
-    String resultScript = ''
+    private StringBuffer resultScript = new StringBuffer()
+
+    /**
+     * the final script buffer as string
+     * @return
+     */
+    String getFinalScript() {
+        resultScript.toString()
+    }
+
+    /**
+     * Add text to the script buffer
+     * @param text
+     */
+    void addText(String scriptText) {
+        resultScript << scriptText
+    }
 
     /**
      * Add a line to javascript output
-     * @param script
-     * @param line
      * @return
      */
     void addLine() {
-        if (resultScript) {
-            resultScript += LS
-        } else {
-            resultScript = ''
+        if (resultScript.size() > 0) {
+            resultScript << LS
         }
-        indent.times { resultScript += TAB }
+        indent.times { resultScript << TAB }
     }
 
     /**
      * Add a tab to out
      */
     void addTab() {
-        resultScript += TAB
+        resultScript << TAB
     }
 
     /**
      * Add a text to javascript output
      * @param text
+     * @param addNewLineChar
      * @return
      */
     private void addScript(text, addNewLineChar = false) {
-        resultScript += text
+        resultScript << text
         if (addNewLineChar) {
             addLine()
         }
@@ -62,8 +75,8 @@ class Out {
      * @param position
      * @return
      */
-    void addScriptAt(text,position) {
-        resultScript = resultScript.substring(0,position) + text + resultScript.substring(position)
+    void addScriptAt(text, position) {
+        resultScript.insert(position, text)
     }
 
     /**
@@ -79,16 +92,16 @@ class Out {
      * @return
      */
     void removeTabScript() {
-        resultScript = resultScript[0..resultScript.size()-1-TAB.size()]
+        resultScript.delete(resultScript.size() - TAB.size(), resultScript.size() - 1)
     }
 
     void block(String text = '', Closure cl) {
         addScript(text + '{')
-        indent ++
+        indent++
         addLine()
         cl()
         addLine()
-        indent --
+        indent--
         removeTabScript()
         addScript('};', true)
     }

--- a/src/main/groovy/org/grooscript/convert/handlers/BlockStatementHandler.groovy
+++ b/src/main/groovy/org/grooscript/convert/handlers/BlockStatementHandler.groovy
@@ -79,7 +79,7 @@ class BlockStatementHandler extends BaseHandler {
 
         //Adds ;
         if (out.resultScript && !(statement instanceof BlockStatement) && !(statement instanceof EmptyStatement)) {
-            out.resultScript += ';'
+            out.addText(';')
             out.addLine()
         }
     }

--- a/src/test/groovy/org/grooscript/convert/TestConversionOptions.groovy
+++ b/src/test/groovy/org/grooscript/convert/TestConversionOptions.groovy
@@ -184,7 +184,7 @@ class TestConversionOptions extends Specification {
         result == "var addToB = function(a) {$LS" +
                   "  gs.mc(console,\"log\",[\"Hello!\"]);$LS" +
                   "  return gs.plus(a, b);$LS" +
-                  "};$LS"
+                  " };$LS"
     }
 
     @Unroll


### PR DESCRIPTION
This improvement to switch from string concatenation to string buffer increases the speed of conversion with at least 100%.   Testing on large (over 5000 lines) and complex (several classes, inheritance, traits  etc) grooscript files, it was found that conversion speed slows down dramatically.  This is due to the fact that Java handles large string concatenation poorly and and the reason for switching to string buffers.

In just running the normal tests on my laptop, the testing time came down from 2 minutes and 28 sec, to 1 minute and 19 sec.

On large files the conversion improvement has been significant.