### PR TITLE
Fix toGroovy JS date conversion

### DIFF
--- a/src/main/resources/META-INF/resources/grooscript.js
+++ b/src/main/resources/META-INF/resources/grooscript.js
@@ -2891,7 +2891,7 @@
     //Convert a javascript object to 'groovy', if you define groovy type, will use it, and not a map
     gs.toGroovy = function(obj, objClass) {
         var result = obj;
-        if (obj !== undefined && !isFunction(obj)) {
+        if (obj !== undefined && !isFunction(obj) && !(obj instanceof Date)) {
             if (obj instanceof Array) {
                 result = gs.list([]);
                 var i;

--- a/src/test/js/test.js
+++ b/src/test/js/test.js
@@ -155,6 +155,8 @@ describe('convert objects between groovy and js', function() {
     it('convert to groovy', function(){
         assert.equal(gs.toGroovy(5), 5);
         assert.equal(gs.toGroovy('hello'), 'hello');
+        var testDate = new Date();
+        assert.equal(gs.toGroovy(testDate), testDate);
         var list = [1, [1, 2], {a:1, b:2}];
         var result = gs.equals(gs.toGroovy(list), gs.list([1, [1, 2], gs.map().add('a',1).add('b', 2)]));
         assert.equal(result, true);


### PR DESCRIPTION
Converting objects that were already JS date objects did not return a JS date